### PR TITLE
efforts towards building aarch64 grobid

### DIFF
--- a/Dockerfile.software
+++ b/Dockerfile.software
@@ -53,19 +53,18 @@ RUN rm -rf grobid-source
 # build runtime image
 # -------------------
 
-# use NVIDIA Container Toolkit to automatically recognize possible GPU drivers on the host machine
-FROM tensorflow/tensorflow:2.7.0-gpu
+FROM python:3.8-slim
 
 # setting locale is likely useless but to be sure
 ENV LANG C.UTF-8
 
 # update NVIDIA Cuda key (following a key rotation in April 2022)
-RUN apt-get install -y wget
-RUN apt-key del 7fa2af80
-RUN rm /etc/apt/sources.list.d/cuda.list
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
+# RUN apt-get install -y wget
+# RUN apt-key del 7fa2af80
+# RUN rm /etc/apt/sources.list.d/cuda.list
+# RUN rm /etc/apt/sources.list.d/nvidia-ml.list
+# RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+# RUN dpkg -i cuda-keyring_1.0-1_all.deb
 
 # install JRE, python and other dependencies
 RUN apt-get update && \
@@ -73,6 +72,7 @@ RUN apt-get update && \
     openjdk-17-jre-headless openjdk-17-jdk ca-certificates-java \
     musl gfortran \
     python3 python3-pip python3-setuptools python3-dev \
+    && export JAVA_HOME \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -82,8 +82,15 @@ COPY --from=builder /opt/grobid .
 
 RUN python3 -m pip install pip --upgrade
 
+RUN pip install tensorflow tensorflow-io
+
 # install DeLFT via pypi
-RUN pip3 install requests delft==0.3.3
+# RUN pip3 install requests delft==0.3.3
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install git+https://github.com/jameshowison/delft
 # link the data directory to /data
 # the current working directory will most likely be /opt/grobid
 RUN mkdir -p /data \
@@ -98,18 +105,18 @@ WORKDIR /opt/grobid
 ENV JAVA_OPTS=-Xmx4g
 
 # install jep (and temporarily the matching JDK)
-ENV JDK_URL=https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
-RUN curl --fail --show-error --location -q ${JDK_URL} -o /tmp/openjdk.tar.gz 
-RUN mkdir /tmp/jdk-17 
-RUN tar xvfz /tmp/openjdk.tar.gz --directory /tmp/jdk-17 --strip-components 1 --no-same-owner 
-RUN /tmp/jdk-17/bin/javac -version
-RUN JAVA_HOME=/tmp/jdk-17 pip3 install jep==4.0.2 
-RUN rm -f /tmp/openjdk.tar.gz 
-RUN rm -rf /tmp/jdk-17
-ENV LD_LIBRARY_PATH=/usr/local/lib/python3.8/dist-packages/jep:grobid-home/lib/lin-64:grobid-home/lib/lin-64/jep:${LD_LIBRARY_PATH}
+# ENV JDK_URL=https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
+# RUN curl --fail --show-error --location -q ${JDK_URL} -o /tmp/openjdk.tar.gz 
+# RUN mkdir /tmp/jdk-17 
+# RUN tar xvfz /tmp/openjdk.tar.gz --directory /tmp/jdk-17 --strip-components 1 --no-same-owner 
+# RUN /tmp/jdk-17/bin/javac -version
+# RUN JAVA_HOME=/tmp/jdk-17 pip3 install jep==4.0.2 
+# RUN rm -f /tmp/openjdk.tar.gz 
+# RUN rm -rf /tmp/jdk-17
+# ENV LD_LIBRARY_PATH=/usr/local/lib/python3.8/dist-packages/jep:grobid-home/lib/lin-64:grobid-home/lib/lin-64/jep:${LD_LIBRARY_PATH}
 # remove libjep.so because we are providing our own version in the virtual env above
-RUN rm /opt/grobid/grobid-home/lib/lin-64/jep/libjep.so
-
+# RUN rm /opt/grobid/grobid-home/lib/lin-64/jep/libjep.so
+RUN JAVA_HOME="$(dirname $(dirname $(readlink -f $(which java))))" pip3 install jep==4.0.2 
 # preload embeddings 
 
 COPY --from=builder /opt/grobid-source/grobid-home/scripts/preload_embeddings.py .
@@ -122,9 +129,10 @@ COPY --from=builder /root/.m2/repository/org /opt/grobid/software-mentions/lib/o
 
 # install Pub2TEI
 WORKDIR /opt/
-RUN wget https://github.com/kermitt2/Pub2TEI/archive/refs/heads/master.zip
-RUN unzip master.zip
-RUN mv Pub2TEI-master Pub2TEI
+RUN git clone --depth 1 https://github.com/kermitt2/Pub2TEI.git
+# RUN wget https://github.com/kermitt2/Pub2TEI/archive/refs/heads/master.zip
+# RUN unzip master.zip
+# RUN mv Pub2TEI-master Pub2TEI
 
 WORKDIR /opt/grobid/software-mentions
 
@@ -138,7 +146,8 @@ RUN ./gradlew --version
 # install all the ML models
 RUN ./gradlew copyModels installModels  && rm -rf resources/models && rm -f /opt/grobid/grobid-home/models/software/model.wapiti.gz && rm -f /opt/grobid/grobid-home/models/software-BERT-0.3.2.zip && rm -f /opt/grobid/grobid-home/models/context_bert-0.3.2.zip && rm -f /opt/grobid/grobid-home/models/context_used_bert-0.3.2.zip && rm -f /opt/grobid/grobid-home/models/context_shared_bert-0.3.2.zip && rm -f /opt/grobid/grobid-home/models/context_creation_bert-0.3.2.zip
 
-RUN ./gradlew clean assemble install --no-daemon --stacktrace --info -x test
+# removed --no-daemon from this as it was causing the docker build to hang. Seems opposite of what one would expect.
+RUN ./gradlew clean assemble install --stacktrace --info -x test
 
 CMD ["sh", "-c", "java --add-opens java.base/java.lang=ALL-UNNAMED -jar build/libs/software-mentions-0.8.0-SNAPSHOT-onejar.jar server resources/config/config.yml"]
 


### PR DESCRIPTION
Just a place to put my halting efforts to get this running on m1 silicon.  See https://github.com/softcite/software-mentions/issues/29

This seems to build well using:

```
docker build --platform=linux/aarch64 -t grobid/software-mentions:0.8.0-SNAPSHOT-aarch64 --build-arg GROBID_VERSION=0.8.0-SNAPSHOT-aarch64 --file Dockerfile.software .
```

Note that the Dockerfile also builds DeLFT from a fork (I had to adjust the dependencies of DeLFT to have the build work).

(the software-mentions folder needs to be inside a grobid clone, then the Dockerfile.software copied to the grobid clone directory).

Unfortunately actually attempting to run the image produces this error:

```
screenit-softcite-server_software_mentions-1  | INFO  [2023-08-01 19:34:43,591] com.hubspot.dropwizard.guicier.DropwizardModule: Added guice injected health check: org.grobid.service.controller.HealthCheck
screenit-softcite-server_software_mentions-1  | com.google.inject.CreationException: Unable to create injector, see the following errors:
screenit-softcite-server_software_mentions-1  | 
screenit-softcite-server_software_mentions-1  | 1) Error injecting constructor, java.lang.UnsatisfiedLinkError: /opt/grobid/grobid-home/lib/lin-64/libwapiti.so: /opt/grobid/grobid-home/lib/lin-64/libwapiti.so: cannot open shared object file: No such file or directory (Possible cause: can't load AMD 64 .so on a AARCH64 platform)
screenit-softcite-server_software_mentions-1  |   at org.grobid.service.GrobidEngineInitialiser.<init>(GrobidEngineInitialiser.java:29)
```

The right library for aarch64 is actually in 

```
jlh5498@INFO-A64206 grobid % ls grobid-home/lib/mac_arm-64 
libwapiti.dylib
```

So next step would be figuring out how to specify the right path for that java library to be loaded.