### PR TITLE
Add needed cd after git clone for source build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ Under the installed and built `grobid/` directory, clone the present module soft
 ```console
 cd grobid/
 git clone https://github.com/softcite/software-mentions
+cd software-mentions
 ```
 
-Copy the provided pre-trained models in the standard grobid-home path:
+Copy the provided pre-trained models into the standard grobid-home path:
 
 ```console
 ./gradlew copyModels 


### PR DESCRIPTION
Building this morning to test instructions, I found that I had to use `cd software-mentions` after clone.  This was confusing, even though this is standard, because the next command mentions `standard grobid-home path` so I thought I had to run the `gradelew` commands from `../software-mentions` (ie the one level up `grobid` directory).